### PR TITLE
Reverted the UI to show only active results by default.

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -358,7 +358,7 @@ type indexData struct {
 	Authenticated bool
 	User          User
 	URI           string
-	ActiveOnly    bool
+	AllResults    bool
 	Submission    submission
 	scanData
 }
@@ -469,7 +469,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 	ip := q.Get("ip")
 	firstSeen := q.Get("firstseen")
 	lastSeen := q.Get("lastseen")
-	_, activeOnly := q["active"]
+	_, allResults := q["all"]
 
 	results, err := resultData(ip, firstSeen, lastSeen)
 	if err != nil {
@@ -487,7 +487,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 		Authenticated: true,
 		User:          user,
 		URI:           r.URL.Path,
-		ActiveOnly:    activeOnly,
+		AllResults:    allResults,
 		Submission:    sub,
 		scanData:      results,
 	}

--- a/views/_header.html
+++ b/views/_header.html
@@ -62,7 +62,7 @@
 						</div>
 					</form>
 					<a class="btn btn-primary navbar-btn" href="/job">New scan</a>
-					<a class="btn btn-{{ if not .ActiveOnly}}success{{ else }}default{{ end }} navbar-btn" href="/{{ if not .ActiveOnly }}?active{{ end }}">Active only</a>
+					<a class="btn btn-{{ if not .AllResults}}success{{ else }}default{{ end }} navbar-btn" href="/{{ if not .AllResults }}?all{{ end }}">All Results</a>
 						{{ end }}
 						{{- if ne .User.Email "" }}
 					<ul class="nav navbar-nav navbar-right">

--- a/views/index.html
+++ b/views/index.html
@@ -14,10 +14,10 @@
 							</tr>
 						</thead>
 						<tbody>
-							{{- $ActiveOnly := .ActiveOnly }}
+							{{- $AllResults := .AllResults }}
 							{{- range .Results }}
 									<tr>
-										{{- if not (and $ActiveOnly .Gone) }}
+										{{- if or $AllResults (not .Gone) }}
 										<td>
 											{{- if .New }}<span class="label label-danger">New</span>{{ end -}}
 											{{- if .Gone }}<span class="label label-success">Gone</span>{{ end -}}


### PR DESCRIPTION
I think @jamesog you were intending to change the UI to only show active results by default to avoid a lag when all the results are loaded on the page. There was a small logic error in what you had implemented, so when I was trying to fix the UI I reverted to the old all results showing by default. Now I've fixed that logic error and gone back to only showing active results by default. 

I also changed the name of the button to All Results. 